### PR TITLE
Bump version to use latest MNE-NIRS and MNE-Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         run: docker run -v /home/runner/example_data/BIDS-NIRS-Tapping-00-Raw-data/:/bids_dataset test --task-label tapping --events "{\"1\":\"Control\", \"2\":\"Tapping/Left\", \"3\":\"Tapping/Right\"}" --duration 5
 
       - name: Ensure generated dataset was valid
-        run: docker run -v /home/runner/example_data/BIDS-NIRS-Tapping-00-Raw-data/:/bids_dataset -v /home/runner/work/fnirs-apps-sourcedata2bids/fnirs-apps-sourcedata2bids/.github/workflows/tests_script.py:/script.py ghcr.io/rob-luke/mne-nirs/image python /script.py
+        run: docker run -v /home/runner/example_data/BIDS-NIRS-Tapping-00-Raw-data/:/bids_dataset -v /home/runner/work/fnirs-apps-sourcedata2bids/fnirs-apps-sourcedata2bids/.github/workflows/tests_script.py:/script.py ghcr.io/mne-tools/mne-nirs:main python /script.py
 
       - uses: actions/upload-artifact@v1
         name: Upload formatted BIDS dataset

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN pip install https://codeload.github.com/rob-luke/mne-bids/zip/nirs
 RUN pip install https://github.com/nilearn/nilearn/archive/main.zip
 RUN pip install https://github.com/mne-tools/mne-nirs/archive/main.zip
 RUN pip install h5py
+RUN pip install h5io
 RUN pip install seaborn
 RUN pip install checksumdir
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This [*fNIRS App*](http://fnirs-apps.org) will convert a directory of fNIRS files to a correctly fomatted BIDS dataset.
 
-To use this app the original measurement files (source data) must be organised according to the file structure specified below.
+The original measurement files (source data) must be organised according to the file structure specified below.
 The app will then convert the raw data to a BIDS dataset, including conversion to SNIRF and creation of all metadata files.
 
 #### Current limitations

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This [*fNIRS App*](http://fnirs-apps.org) will convert a directory of fNIRS files to a correctly fomatted BIDS dataset.
 
-The original measurement files (source data) must be organised according to the file structure specified below.
+To use this app the original measurement files (source data) must be organised according to the file structure specified below.
 The app will then convert the raw data to a BIDS dataset, including conversion to SNIRF and creation of all metadata files.
 
 #### Current limitations

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The app will then convert the raw data to a BIDS dataset, including conversion t
 
 * Only works with NIRx and SNIRF files. However due to support in MNE, it will be trivial to extend to Hitachi, Imagent, Artinis datatypes too. Raise an issue if you need this feature.
 
-**Feedback is welcome!!** Please let me know your experience with this app by raising an issue.  
+**Feedback is welcome!!** Please let me know your experience with this app by raising an issue.
 
 
 ## Usage


### PR DESCRIPTION
Following https://github.com/mne-tools/mne-nirs/pull/429 the files created by MNE are now fully compatible with pysnirf2